### PR TITLE
Update fetch queries for page types in webapp/fullstack examples

### DIFF
--- a/fullstack/backend/java/src/main/java/com/example/backendjava/Query.java
+++ b/fullstack/backend/java/src/main/java/com/example/backendjava/Query.java
@@ -9,16 +9,9 @@ public class Query {
             "id": $page.page-id,
             "profile-picture": $page.profile-picture,
             "type": (
-                match {
-                    $page isa person;
-                    let $ty = "person";
-                } or {
-                    $page isa organization;
-                    let $ty = "organization";
-                } or {
-                    $page isa group;
-                    let $ty = "group";
-                };
+                match
+                { $ty label person; } or { $ty label organization; } or { $ty label group; };
+                $page isa $ty;
                 return first $ty;
             ),
         };
@@ -41,13 +34,9 @@ public class Query {
                         "id": $page.page-id,
                         "profilePicture": $page.profile-picture,
                         "type": (
-                            match {
-                                $page isa person;
-                                let $ty = "person";
-                            } or {
-                                $page isa organization;
-                                let $ty = "organization";
-                            };
+                            match
+                            { $ty label person; } or { $ty label organization; };
+                            $page isa $ty;
                             return first $ty;
                         ),
                     };
@@ -124,16 +113,9 @@ public class Query {
                 "authorProfilePicture": $page.profile-picture,
                 "authorId": $page.page-id,
                 "authorType": (
-                    match {
-                        $page isa person;
-                        let $ty = "person";
-                    } or {
-                        $page isa organization;
-                        let $ty = "organization";
-                    } or {
-                        $page isa group;
-                        let $ty = "group";
-                    };
+                    match
+                    { $ty label person; } or { $ty label organization; } or { $ty label group; };
+                    $page isa $ty;
                     return first $ty;
                 ),
                 "reactions": [
@@ -156,13 +138,9 @@ public class Query {
                 "authorProfilePicture": $author.profile-picture,
                 "authorId": $author.page-id,
                 "authorType": (
-                    match {
-                        $author isa person;
-                        let $ty = "person";
-                    } or {
-                        $author isa organization;
-                        let $ty = "organization";
-                    };
+                    match
+                    { $ty label person; } or { $ty label organization; };
+                    $page isa $ty;
                     return first $ty;
                 ),
                 "reactions": [

--- a/fullstack/backend/python/queries.py
+++ b/fullstack/backend/python/queries.py
@@ -8,16 +8,9 @@ fetch {
     "id": $page.page-id,
     "profile-picture": $page.profile-picture,
     "type": (
-        match {
-            $page isa person;
-            let $ty = "person";
-        } or {
-            $page isa organization;
-            let $ty = "organization";
-        } or {
-            $page isa group;
-            let $ty = "group";
-        };
+        match
+        { $ty label person; } or { $ty label organization; } or { $ty label group; };
+        $page isa $ty;
         return first $ty;
     ),
 };
@@ -40,13 +33,9 @@ def location_query(place_id):
                     "id": $page.page-id,
                     "profilePicture": $page.profile-picture,
                     "type": (
-                        match {{
-                            $page isa person;
-                            let $ty = "person";
-                        }} or {{
-                            $page isa organization;
-                            let $ty = "organization";
-                        }};
+                        match
+                        {{ $ty label person; }} or {{ $ty label organization; }};
+                        $page isa $ty;
                         return first $ty;
                     ),
                 }};
@@ -123,16 +112,9 @@ def posts_query(page_id):
             "authorProfilePicture": $page.profile-picture,
             "authorId": $page.page-id,
             "authorType": (
-                match {{
-                    $page isa person;
-                    let $ty = \"person\";
-                }} or {{
-                    $page isa organization;
-                    let $ty = \"organization\";
-                }} or {{
-                    $page isa group;
-                    let $ty = \"group\";
-                }};
+                match
+                {{ $ty label person; }} or {{ $ty label organization; }} or {{ $ty label group; }};
+                $page isa $ty;
                 return first $ty;
             ),
             "reactions": [
@@ -155,13 +137,9 @@ def comments_query(post_id):
             "authorProfilePicture": $author.profile-picture,
             "authorId": $author.page-id,
             "authorType": (
-                match {{
-                    $author isa person;
-                    let $ty = \"person\";
-                }} or {{
-                    $author isa organization;
-                    let $ty = \"organization\";
-                }};
+                match
+                {{ $ty label person; }} or {{ $ty label organization; }};
+                $page isa $ty;
                 return first $ty;
             ),
             "reactions": [

--- a/fullstack/backend/rust/src/query.rs
+++ b/fullstack/backend/rust/src/query.rs
@@ -10,16 +10,9 @@ fetch {
     "id": $page.page-id,
     "profile-picture": $page.profile-picture,
     "type": (
-        match {
-            $page isa person;
-            let $ty = "person";
-        } or {
-            $page isa organization;
-            let $ty = "organization";
-        } or {
-            $page isa group;
-            let $ty = "group";
-        };
+        match
+        { $ty label person; } or { $ty label organization; } or { $ty label group; };
+        $page isa $ty;
         return first $ty;
     ),
 };"#;
@@ -42,13 +35,9 @@ pub fn location_query(place_id: &str) -> String {
                     "id": $page.page-id,
                     "profilePicture": $page.profile-picture,
                     "type": (
-                        match {{
-                            $page isa person;
-                            let $ty = "person";
-                        }} or {{
-                            $page isa organization;
-                            let $ty = "organization";
-                        }};
+                        match
+                        {{ $ty label person; }} or {{ $ty label organization; }};
+                        $page isa $ty;
                         return first $ty;
                     ),
                 }};
@@ -131,16 +120,9 @@ pub fn posts_query(page_id: &str) -> String {
             "authorProfilePicture": $page.profile-picture,
             "authorId": $page.page-id,
             "authorType": (
-                match {{
-                    $page isa person;
-                    let $ty = "person";
-                }} or {{
-                    $page isa organization;
-                    let $ty = "organization";
-                }} or {{
-                    $page isa group;
-                    let $ty = "group";
-                }};
+                match
+                {{ $ty label person; }} or {{ $ty label organization; }} or {{ $ty label group; }};
+                $page isa $ty;
                 return first $ty;
             ),
             "reactions": [
@@ -166,13 +148,9 @@ pub fn comments_query(post_id: &str) -> String {
             "authorProfilePicture": $author.profile-picture,
             "authorId": $author.page-id,
             "authorType": (
-                match {{
-                    $author isa person;
-                    let $ty = "person";
-                }} or {{
-                    $author isa organization;
-                    let $ty = "organization";
-                }};
+                match
+                {{ $ty label person; }} or {{ $ty label organization; }};
+                $page isa $ty;
                 return first $ty;
             ),
             "reactions": [

--- a/fullstack/frontend/src/components/CommentList.tsx
+++ b/fullstack/frontend/src/components/CommentList.tsx
@@ -4,6 +4,7 @@ import ReactionsBar from './ReactionsBar';
 import { Comment } from '../model/Post';
 // @ts-ignore
 import userAvatar from '../assets/userAvatar.svg';
+import { getProfileUrl } from "../model/Page";
 
 interface CommentListProps {
   postId: string;
@@ -58,13 +59,6 @@ export default function CommentList({ postId }: CommentListProps) {
     }
   }, [comments]);
 
-  function getProfileUrl(type: string, id: string): string {
-    if (type === 'person') return `/user/${id}`;
-    if (type === 'organization') return `/organization/${id}`;
-    if (type === 'group') return `/group/${id}`;
-    return '/';
-  }
-
   if (loading) return <div>No comments yet.</div>;
   if (error) return <div>Error: {error}</div>;
   if (!comments.length) return <div>No comments yet.</div>;
@@ -74,7 +68,7 @@ export default function CommentList({ postId }: CommentListProps) {
       {comments.map(c => (
         <div key={c.commentId} style={{ display: 'flex', gap: 12, alignItems: 'flex-start', position: 'relative', paddingBottom: 20, border: '1px solid #e0e0e0', borderRadius: 8, padding: 12 }}>
           <a 
-            href={getProfileUrl(c.authorType, c.authorId)}
+            href={getProfileUrl(c.authorType.label, c.authorId)}
             style={{ textDecoration: 'none' }}
           >
             <div 
@@ -107,7 +101,7 @@ export default function CommentList({ postId }: CommentListProps) {
           <div style={{ flex: 1 }}>
             <div style={{ display: 'block', marginBottom: 4 }}>
             <a 
-              href={getProfileUrl(c.authorType, c.authorId)}
+              href={getProfileUrl(c.authorType.label, c.authorId)}
               style={{ 
                 fontSize: '12px', 
                 color: '#007bff', 

--- a/fullstack/frontend/src/components/CreatePage.tsx
+++ b/fullstack/frontend/src/components/CreatePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ServiceContext } from "../service/ServiceContext";
-import { Page } from "../model/Page";
+import { getProfileUrl, Page } from "../model/Page";
 import { User } from "../model/User";
 import { Organization } from "../model/Organization";
 import { Group } from "../model/Group";
@@ -118,10 +118,7 @@ export default function CreatePage() {
     promise
       .then(() => {
         setFormLoading(false);
-        if (type === 'person') navigate(`/user/${id}`);
-        else if (type === 'organization') navigate(`/organization/${id}`);
-        else if (type === 'group') navigate(`/group/${id}`);
-        else navigate('/');
+        navigate(getProfileUrl(type, id));
       })
       .catch(e => {
         setFormError(e.message);

--- a/fullstack/frontend/src/components/PageCard.tsx
+++ b/fullstack/frontend/src/components/PageCard.tsx
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom';
 // @ts-ignore
 import userAvatar from '../assets/userAvatar.svg';
 import { ServiceContext } from "../service/ServiceContext";
+import { getProfileUrl, PageType } from "../model/Page";
 
 interface PageCardProps {
   id: string;
-  type: 'person' | 'organization' | 'group';
+  type: PageType;
   name: string;
   profilePictureId: string;
   scale?: number;
@@ -33,11 +34,7 @@ export default function PageCard({ id, type, name, profilePictureId, scale = 1 }
     return () => { isMounted = false; };
   }, [profilePictureId]);
 
-  let link = '/';
-  if (type === 'person') link = `/user/${id}`;
-  else if (type === 'organization') link = `/organization/${id}`;
-  else if (type === 'group') link = `/group/${id}`;
-
+  const link = getProfileUrl(type.label, id);
   const avatarSize = 80 * scale;
   const cardWidth = 150 * scale;
   const marginBottom = 8 * scale;
@@ -54,7 +51,7 @@ export default function PageCard({ id, type, name, profilePictureId, scale = 1 }
       </div>
       <div style={{ fontSize: fontSize, fontWeight: 500, color: '#1976d2', maxWidth: '100%', textOverflow: 'ellipsis', overflow: 'hidden' }}>{name}</div>
       <div style={{ fontSize: 12, color: '#888' }}>
-        {type === 'person' ? 'User' : type === 'organization' ? 'Organization' : 'Group'}
+        {type.label === 'person' ? 'User' : type.label === 'organization' ? 'Organization' : 'Group'}
       </div>
     </Link>
   );

--- a/fullstack/frontend/src/components/PageList.tsx
+++ b/fullstack/frontend/src/components/PageList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageCard from './PageCard';
 import { ServiceContext } from '../service/ServiceContext';
-import { Page, pageTypes } from "../model/Page";
+import { Page, pageTypeLabels } from "../model/Page";
 
 export default function PageList() {
   const [pages, setPages] = useState<Page[]>([]);
@@ -55,7 +55,7 @@ export default function PageList() {
                 All
               </button>
             </li>
-            {pageTypes.map(type => (
+            {pageTypeLabels.map(type => (
               <li key={type}>
                 <button
                   style={{
@@ -80,7 +80,7 @@ export default function PageList() {
         </div>
         {/* Main List */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16, flex: 1 }}>
-          {(filter ? pages.filter(page => page.type === filter) : pages).map(page => (
+          {(filter ? pages.filter(page => page.type.label === filter) : pages).map(page => (
             <div key={page.id} style={{ display: 'flex', gap: 16, padding: 16, border: '1px solid #eee', borderRadius: 8, alignItems: 'center' }}>
               <PageCard
                 id={page.id}

--- a/fullstack/frontend/src/components/Post.tsx
+++ b/fullstack/frontend/src/components/Post.tsx
@@ -6,6 +6,7 @@ import { ServiceContext } from "../service/ServiceContext";
 import { PostType } from "../model/Post";
 // @ts-ignore
 import userAvatar from '../assets/userAvatar.svg';
+import { PageType } from "../model/Page";
 
 interface PostProps {
   post: PostType;
@@ -43,10 +44,10 @@ export default function Post({ post }: PostProps) {
     setTimeout(() => setClicked(false), 150);
   }
 
-  function getProfileUrl(type: string, id: string): string {
-    if (type === 'person') return `/user/${id}`;
-    if (type === 'organization') return `/organization/${id}`;
-    if (type === 'group') return `/group/${id}`;
+  function getProfileUrl(type: PageType, id: string): string {
+    if (type.label === 'person') return `/user/${id}`;
+    if (type.label === 'organization') return `/organization/${id}`;
+    if (type.label === 'group') return `/group/${id}`;
     return '/';
   }
 

--- a/fullstack/frontend/src/components/UserProfilePage.tsx
+++ b/fullstack/frontend/src/components/UserProfilePage.tsx
@@ -7,12 +7,12 @@ import { ServiceContext } from '../service/ServiceContext';
 import userAvatar from '../assets/userAvatar.svg';
 import { User } from "../model/User";
 import { getLocationParts } from "../model/Location";
-import { Page } from "../model/Page";
+import { Page, PageType } from "../model/Page";
 
 interface FriendPage {
   id: string;
   name: string;
-  type: 'person' | 'organization' | 'group';
+  type: PageType;
   profilePictureId: string;
 }
 
@@ -60,7 +60,7 @@ export default function UserProfilePage() {
       serviceContext.fetchPages()
         .then((allPages: Page[]) => {
           const friendPages = allPages.filter(page => 
-            user.friends.includes(page.id) && page.type === 'person'
+            user.friends.includes(page.id) && page.type.label === 'person'
           ).map(page => ({
             id: page.id,
             name: page.name,

--- a/fullstack/frontend/src/model/Group.tsx
+++ b/fullstack/frontend/src/model/Group.tsx
@@ -1,7 +1,7 @@
-import { Page } from "./Page";
+import { Page, PageType } from "./Page";
 
 export interface Group extends Page {
-    type: 'group';
+    type: PageType<'group'>;
     groupId?: string;
     tags?: string[];
     pageVisibility?: string;

--- a/fullstack/frontend/src/model/Organization.tsx
+++ b/fullstack/frontend/src/model/Organization.tsx
@@ -1,6 +1,6 @@
-import { Profile } from "./Page";
+import { PageType, Profile } from "./Page";
 
 export interface Organization extends Profile {
-    type: 'organization';
+    type: PageType<'organization'>;
     tags?: string[];
 }

--- a/fullstack/frontend/src/model/Page.tsx
+++ b/fullstack/frontend/src/model/Page.tsx
@@ -1,7 +1,10 @@
 import { LocationItem } from "./Location";
 
-export const pageTypes = ['person', 'organization', 'group'] as const;
-export type PageType = typeof pageTypes[number];
+export const pageTypeLabels = ['person', 'organization', 'group'] as const;
+export type PageTypeLabel = typeof pageTypeLabels[number];
+export interface PageType<T extends PageTypeLabel = PageTypeLabel> {
+    label: T;
+}
 
 export interface Page {
     id: string;
@@ -26,9 +29,16 @@ export interface FollowerPage {
 }
 
 export interface Profile extends Page {
-    type: 'person' | 'organization';
+    type: PageType<'person' | 'organization'>;
     username?: string;
     canPublish?: boolean;
     location?: LocationItem[];
+}
+
+export function getProfileUrl(typeLabel: string, id: string): string {
+    if (typeLabel === 'person') return `/user/${id}`;
+    if (typeLabel === 'organization') return `/organization/${id}`;
+    if (typeLabel === 'group') return `/group/${id}`;
+    return '/';
 }
 

--- a/fullstack/frontend/src/model/Post.tsx
+++ b/fullstack/frontend/src/model/Post.tsx
@@ -1,3 +1,5 @@
+import { PageType } from "./Page";
+
 export interface PostType {
     postText: string;
     postVisibility: string;
@@ -10,7 +12,7 @@ export interface PostType {
     authorName: string;
     authorProfilePicture: string;
     authorId: string;
-    authorType: 'person' | 'organization' | 'group';
+    authorType: PageType;
     reactions: string[];
 }
 
@@ -22,6 +24,6 @@ export interface Comment {
     authorName: string;
     authorProfilePicture: string;
     authorId: string;
-    authorType: 'person' | 'organization' | 'group';
+    authorType: PageType;
     reactions: string[];
 }

--- a/fullstack/frontend/src/model/User.tsx
+++ b/fullstack/frontend/src/model/User.tsx
@@ -1,7 +1,7 @@
-import { Profile } from "./Page";
+import { PageType, Profile } from "./Page";
 
 export interface User extends Profile {
-    type: 'person';
+    type: PageType<'person'>;
     gender?: string;
     language?: string;
     email?: string;

--- a/webapp/src/AppService.tsx
+++ b/webapp/src/AppService.tsx
@@ -92,16 +92,9 @@ async function fetchPages(): Promise<Page[]> {
             "id": $page.page-id,
             "profile-picture": $page.profile-picture,
             "type": (
-                match {
-                    $page isa person;
-                    let $ty = "person";
-                } or {
-                    $page isa organization;
-                    let $ty = "organization";
-                } or {
-                    $page isa group;
-                    let $ty = "group";
-                };
+                match
+                { $ty label person; } or { $ty label organization; } or { $ty label group; };
+                $page isa $ty;
                 return first $ty;
             ),
         };
@@ -126,16 +119,9 @@ async function fetchPosts(pageId: string): Promise<PostType[]> {
             "authorProfilePicture": $page.profile-picture,
             "authorId": $page.page-id,
             "authorType": (
-                match {
-                    $page isa person;
-                    let $ty = "person";
-                } or {
-                    $page isa organization;
-                    let $ty = "organization";
-                } or {
-                    $page isa group;
-                    let $ty = "group";
-                };
+                match
+                { $ty label person; } or { $ty label organization; } or { $ty label group; };
+                $page isa $ty;
                 return first $ty;
             ),
             "reactions": [
@@ -159,13 +145,9 @@ async function fetchComments(postId: string): Promise<Comment[]> {
             "authorProfilePicture": $author.profile-picture,
             "authorId": $author.page-id,
             "authorType": (
-                match {
-                    $author isa person;
-                    let $ty = "person";
-                } or {
-                    $author isa organization;
-                    let $ty = "organization";
-                };
+                match
+                { $ty label person; } or { $ty label organization; };
+                $author isa $ty;
                 return first $ty;
             ),
             "reactions": [
@@ -193,13 +175,9 @@ async function fetchLocationPages(placeId: string): Promise<LocationPage[]> {
                     "id": $page.page-id,
                     "profilePicture": $page.profile-picture,
                     "type": (
-                        match {
-                            $page isa person;
-                            let $ty = "person";
-                        } or {
-                            $page isa organization;
-                            let $ty = "organization";
-                        };
+                        match
+                        { $ty label person; } or { $ty label organization; };
+                        $page isa $ty;
                         return first $ty;
                     ),
                 };


### PR DESCRIPTION
## What is the goal of this PR?

Simplify the portion of the `fetch` queries in the webapp and fullstack examples where they retrieve the type (person/organization/group) of a given page.

## What are the changes implemented in this PR?

We match the label of the type, and then return the entire type object without constructing intermediary string representations. We update the frontend to use this wrapped object instead of the string directly.