### PR TITLE
Add sample datasets manifest file for TypeDB client apps

### DIFF
--- a/sample-datasets.yml
+++ b/sample-datasets.yml
@@ -1,5 +1,6 @@
 # Sample dataset manifest for TypeDB clients (Studio, Cloud platform, etc.).
 # Only TypeDB server versions >= 3.5.0 are covered.
+# Clients may optionally include pre-release server builds (e.g. 3.8.0-alpha-1) in server ranges.
 # This file should be updated when adding new datasets or releasing new versions of existing ones.
 
 schemaVersion: 1

--- a/sample-datasets.yml
+++ b/sample-datasets.yml
@@ -1,0 +1,94 @@
+# Sample dataset manifest for TypeDB clients (Studio, Cloud platform, etc.).
+# Only TypeDB server versions >= 3.5.0 are covered.
+# This file should be updated when adding new datasets or releasing new versions of existing ones.
+
+schemaVersion: 1
+
+datasets:
+  bookstore:
+    displayName: "Bookstore"
+    description: "A simplified ecommerce model of a bookstore, with books, users, orders, reviews, and promotions."
+    homepage: "https://github.com/typedb/typedb-examples/tree/master/use-cases/bookstore"
+    versions:
+      - version: "3.7.1"
+        compatibleServers: ">=3.7.3"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.7.1/bookstore-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.7.1/bookstore-data.tql"
+      - version: "3.7.0"
+        compatibleServers: ">=3.7.0 <3.7.3"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.7.0/bookstore-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.7.0/bookstore-data.tql"
+      - version: "3.5.5"
+        compatibleServers: ">=3.5.5 <3.7.0"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.5/bookstore-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.5/bookstore-data.tql"
+      - version: "3.5.2"
+        compatibleServers: ">=3.5.2 <3.5.5"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.2/bookstore-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.2/bookstore-data.tql"
+      - version: "3.5.1"
+        compatibleServers: ">=3.5.1 <3.5.2"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.1/bookstore-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.1/bookstore-data.tql"
+      - version: "3.5.0"
+        compatibleServers: ">=3.5.0 <3.5.1"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-data.tql"
+
+  social-network:
+    displayName: "Social Network"
+    description: "A moderately complex model of a modern social network, capturing users, content, and their interactions."
+    homepage: "https://github.com/typedb/typedb-examples/tree/master/use-cases/social-network"
+    versions:
+      - version: "3.7.1"
+        compatibleServers: ">=3.7.3"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.7.1/social-network-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.7.1/social-network-data.tql"
+      - version: "3.7.0"
+        compatibleServers: ">=3.7.0 <3.7.3"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.7.0/social-network-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.7.0/social-network-data.tql"
+      - version: "3.5.5"
+        compatibleServers: ">=3.5.5 <3.7.0"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.5/social-network-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.5/social-network-data.tql"
+      - version: "3.5.2"
+        compatibleServers: ">=3.5.2 <3.5.5"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.2/social-network-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.2/social-network-data.tql"
+      - version: "3.5.1"
+        compatibleServers: ">=3.5.1 <3.5.2"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.1/social-network-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.1/social-network-data.tql"
+      - version: "3.5.0"
+        compatibleServers: ">=3.5.0 <3.5.1"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.0/social-network-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.0/social-network-data.tql"
+
+  cti:
+    displayName: "Cyber Threat Intelligence"
+    description: "A STIX 2.1-based model of threat actors, campaigns, and their relationships, demonstrating TypeDB in a CTI context."
+    homepage: "https://github.com/typedb/typedb-examples/tree/master/use-cases/cyber-threat-intelligence"
+    versions:
+      - version: "3.7.1"
+        compatibleServers: ">=3.7.3"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.7.1/cti-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.7.1/cti-data.tql"
+      - version: "3.7.0"
+        compatibleServers: ">=3.7.0 <3.7.3"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.7.0/cti-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.7.0/cti-data.tql"
+      - version: "3.5.5"
+        compatibleServers: ">=3.5.6 <3.7.0"
+        schemaFile: "https://github.com/typedb/typedb-examples/releases/download/3.5.5/cti-schema.tql"
+        dataFile:   "https://github.com/typedb/typedb-examples/releases/download/3.5.5/cti-data.tql"
+
+  robotics:
+    displayName: "Robotics"
+    description: "A knowledge base for an autonomous robotic agent, based on a real-world application of TypeDB."
+    homepage: "https://github.com/typedb-osi/typedb-robotics"
+    versions:
+      - version: "1.0.0"
+        compatibleServers: ">=3.5.0"
+        schemaFile: "https://github.com/typedb-osi/typedb-robotics/releases/download/1.0.0/schema_floorplan.tql"
+        dataFile:   "https://github.com/typedb-osi/typedb-robotics/releases/download/1.0.0/data_floorplan_assignment.tql"

--- a/sample-datasets.yml
+++ b/sample-datasets.yml
@@ -2,6 +2,7 @@
 # Only TypeDB server versions >= 3.5.0 are covered.
 # Clients may optionally include pre-release server builds (e.g. 3.8.0-alpha-1) in server ranges.
 # This file should be updated when adding new datasets or releasing new versions of existing ones.
+# Do NOT delete this file - it is used by live clients.
 
 schemaVersion: 1
 


### PR DESCRIPTION
## Product change and motivation

We add `sample-datasets.yml`, which can be used by TypeDB clients to autonomously scrape sample datasets.

## Implementation

`sample-datasets.yml` consists of a list of datasets (`robotics`, `cti`, etc.). Each dataset has a list of versions. Each dataset version has a data file URL, a schema file URL, and a `compatibleServers` semver range that indicates which TypeDB server versions work with this sample dataset version.

We should update the manifest file when releasing new datasets or dataset versions.